### PR TITLE
Add logging

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -38,7 +38,23 @@ Profiles:
     """
 }
 
+def config_info = """
+General parameters:
+Output directory = $params.outdir
+Sample sheet     = $params.samplesheet
+Paired end reads = $params.paired_reads
 
+Barcode Filtering Parameters:
+Min barcode length   = $params.min_bc_len
+Max barcode length   = $params.max_bc_len
+Minimum count butoff = $params.barcode_cutoff
+
+Error correction parameters:
+Error correction performed = $params.correct
+Minimum centroid           = $params.min_centroid
+Correction Error Rate      = $params.correct_error_rate
+Max edits                  = $params.max_edits
+"""
 
 workflow {
 
@@ -57,26 +73,7 @@ Short Read Processing Pipeline
         exit 0
     }
 
-    // Log Outputs
-    
-    config_info = """
-General parameters:
-Output directory = $params.outdir
-Sample sheet     = $params.samplesheet
-Paired end reads = $params.paired_reads
-
-Barcode Filtering Parameters:
-Min barcode length   = $params.min_bc_len
-Max barcode length   = $params.max_bc_len
-Minimum count butoff = $params.barcode_cutoff
-
-Error correction parameters:
-Error correction performed = $params.correct
-Minimum centroid           = $params.min_centroid
-Correction Error Rate      = $params.correct_error_rate
-Max edits                  = $params.max_edits
-"""
-
+    log_params()
 
     // Paired end flow
 
@@ -114,8 +111,6 @@ Max edits                  = $params.max_edits
         }
 
     }
-
-    log_params()
 
     r_stats = read_stats(samples)
 

--- a/main.nf
+++ b/main.nf
@@ -47,12 +47,12 @@ Paired end reads = $params.paired_reads
 Barcode Filtering Parameters:
 Min barcode length   = $params.min_bc_len
 Max barcode length   = $params.max_bc_len
-Minimum count butoff = $params.barcode_cutoff
+Minimum count cutoff = $params.barcode_cutoff
 
 Error correction parameters:
 Error correction performed = $params.correct
 Minimum centroid           = $params.min_centroid
-Correction Error Rate      = $params.correct_error_rate
+Correction error rate      = $params.correct_error_rate
 Max edits                  = $params.max_edits
 """
 

--- a/main.nf
+++ b/main.nf
@@ -57,6 +57,27 @@ Short Read Processing Pipeline
         exit 0
     }
 
+    // Log Outputs
+    
+    config_info = """
+General parameters:
+Output directory = $params.outdir
+Sample sheet     = $params.samplesheet
+Paired end reads = $params.paired_reads
+
+Barcode Filtering Parameters:
+Min barcode length   = $params.min_bc_len
+Max barcode length   = $params.max_bc_len
+Minimum count butoff = $params.barcode_cutoff
+
+Error correction parameters:
+Error correction performed = $params.correct
+Minimum centroid           = $params.min_centroid
+Correction Error Rate      = $params.correct_error_rate
+Max edits                  = $params.max_edits
+"""
+
+
     // Paired end flow
 
     if ( params.paired_reads ) {
@@ -93,6 +114,8 @@ Short Read Processing Pipeline
         }
 
     }
+
+    log_params()
 
     r_stats = read_stats(samples)
 
@@ -158,6 +181,19 @@ Short Read Processing Pipeline
     // report
     template = channel.fromPath("${projectDir}/assets/report_template.ipynb")
     prepare_report(template)
+}
+
+
+process log_params {
+    publishDir("$params.outdir"),  mode: 'copy'
+
+    output:
+    path "nextflow_config_params.txt"
+
+    script:
+    """
+    echo '$config_info' > nextflow_config_params.txt
+    """
 }
 
 process get_flanks {


### PR DESCRIPTION
This PR adds very simple configuration logging to the short read pipeline output.

It is now possible to see exactly what parameters were called to generate the data in that respective folder. Prior to this update, it would be necessary to somehow track this down by finding the Seqera run corresponding to a given output file.

The parent output directory now contains a file named: nextflow_config_params.txt

This file contains a record of the important configuration parameters that relate to how the data is processed. It looks something like this (but with the typo in cutoff fixed)

<img width="1095" height="242" alt="image" src="https://github.com/user-attachments/assets/bc4f43d4-8f33-4420-a1c6-62f3e575fb10" />
